### PR TITLE
error while using say fixed

### DIFF
--- a/commands/fun/say.cpscmd/s.js
+++ b/commands/fun/say.cpscmd/s.js
@@ -1,6 +1,6 @@
 module.exports = {
   name: 's',
-  func(msg, { send, author, suffix, Constants }) {
+  func(msg, { send, reply, author, suffix, Constants }) {
     if (author.id === Constants.users.WILLYZ ||
       author.id === Constants.users.EVILDEATHPRO ||
       author.id === Constants.users.LUCAS ||
@@ -9,6 +9,7 @@ module.exports = {
     ) {
       // Antonio, 166..12
 
+      if(suffix === "") return reply("Please include a message for the bot to repeat");
       msg.delete().catch(_ => _);
       return send(suffix, { disableEveryone: true });
     }


### PR DESCRIPTION
Fixed an error where if no message parsed after say bot would try and send it anyways.


**Please describe the changes this PR makes and why we should accept it**
This PR fixes an error where if someone tried to use say command without any parameters, the bot would try and send it, resulting in an DiscordAPIError.

**Select which apply:**
- [✓] This PR changes/adds bot command(s).
- [ ] This PR changes/adds to the internal bot structure.
- [ ] This PR includes breaking changes (methods or files removed or renamed, parameters moved or removed)
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, etc.
- [✓] I have verified my code with a current Chips developer
  - [✓] If so, indicate who: LucasLSG

**Make sure you have done these, if you haven't we will automatically reject the PR:**
- [ ] I have verified that my linter works properly
- [ ] I have fixed any and all issues that my linter may have alerted me.
- [✓] I have verified that my code is consistent with surrounding and dependent code (e.g. in command files I do not use msg.send instead of importing send unless send is being overriden).
